### PR TITLE
Issue two resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [2.5.2-dev] - 2026-02-03
+
+### Fixed
+
+- **api/stores.php, api/transactions.php, book.php** — Use `User::generateUuid()` instead of `$userRepo->generateUuid()` (static method called as instance method, causes deprecation/fatal on PHP 8+). Fixes issue #2.
+
+---
+
 ## [2.5.1-dev] - 2026-01-31
 
 ### Added

--- a/app/public/api/stores.php
+++ b/app/public/api/stores.php
@@ -27,7 +27,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         echo json_encode(['error' => 'Invalid storename']);
         exit;
     }
-    $uuid = $userRepo->generateUuid();
+    $uuid = User::generateUuid();
     $now = date('Y-m-d H:i:s');
     $pdo->prepare('INSERT INTO stores (uuid, storename, description, vendorship_agreed_at, is_free, created_at) VALUES (?, ?, ?, ?, 1, ?)')->execute([$uuid, $storename, $description, $agree ? $now : null, $now]);
     $pdo->prepare('INSERT INTO store_users (store_uuid, user_uuid, role) VALUES (?, ?, ?)')->execute([$uuid, $user['uuid'], 'owner']);

--- a/app/public/api/transactions.php
+++ b/app/public/api/transactions.php
@@ -38,7 +38,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         echo json_encode(['error' => 'Package not found']);
         exit;
     }
-    $txUuid = $userRepo->generateUuid();
+    $txUuid = User::generateUuid();
     $now = date('Y-m-d H:i:s');
     $pdo->prepare('INSERT INTO transactions (uuid, type, description, package_uuid, store_uuid, buyer_uuid, refund_address, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')->execute([$txUuid, 'evm', '', $packageUuid, $storeRow['store_uuid'], $user['uuid'], $refundAddress ?: null, $now]);
     $pdo->prepare('INSERT INTO evm_transactions (uuid, amount, chain_id, currency, created_at) VALUES (?, ?, ?, ?, ?)')->execute([$txUuid, $requiredAmount, $chainId, $currency, $now]);

--- a/app/public/book.php
+++ b/app/public/book.php
@@ -37,7 +37,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $requiredAmount = (float) ($_POST['required_amount'] ?? 0);
     $chainId = (int) ($_POST['chain_id'] ?? 1);
     $currency = trim((string) ($_POST['currency'] ?? 'ETH'));
-    $txUuid = $userRepo->generateUuid();
+    $txUuid = User::generateUuid();
     $now = date('Y-m-d H:i:s');
     $pdo->prepare('INSERT INTO transactions (uuid, type, description, package_uuid, store_uuid, buyer_uuid, refund_address, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')->execute([$txUuid, 'evm', '', $packageUuid, $package['store_uuid'], $currentUser['uuid'], $refundAddress ?: null, $now]);
     $pdo->prepare('INSERT INTO evm_transactions (uuid, amount, chain_id, currency, created_at) VALUES (?, ?, ?, ?, ?)')->execute([$txUuid, $requiredAmount, $chainId, $currency, $now]);


### PR DESCRIPTION
Fixes issue #2 by changing `User::generateUuid()` calls from instance to static methods.

The `generateUuid()` method in `User.php` is declared as `public static function`, but it was being called via an instance (`$userRepo->generateUuid()`) in `app/public/api/stores.php`, `app/public/api/transactions.php`, and `app/public/book.php`. This change ensures the correct static method invocation, preventing deprecation warnings or fatal errors on PHP 8+.

---
<a href="https://cursor.com/background-agent?bcId=bc-b92a5552-bed6-4610-b126-825929fc522d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b92a5552-bed6-4610-b126-825929fc522d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

