### PR TITLE
Gh issue view failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [2.5.17-dev] - 2026-02-12
+
+### Added
+
+- **api/transaction-actions.php (issue #26)** — New API endpoint to request transaction intents: `release`, `cancel`, `partial_refund`. Supports API key/agent identity auth (no CSRF) and session auth (CSRF required) and enforces action permissions to match the web flows.
+
+### Documentation
+
+- **ARCHITECTURE.md (issue #26)** — Corrected release flow docs to reflect the real trigger paths (web `payment.php` and the new API endpoint).
+- **API docs (issue #26)** — Documented `POST /api/transaction-actions.php` and added it to quick references.
+
+### Tests
+
+- **E2E (issue #26)** — Added coverage for transaction action auth/CSRF, permission denials, and successful intent writes.
+
 ## [2.5.16-dev] - 2026-02-07
 
 ### Added

--- a/app/public/api/transaction-actions.php
+++ b/app/public/api/transaction-actions.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * POST /api/transaction-actions.php — Request transaction intents (release/cancel/partial_refund).
+ * Auth: API key/agent identity OR session (+ CSRF).
+ */
+require_once __DIR__ . '/../includes/bootstrap.php';
+require_once __DIR__ . '/../includes/api_helpers.php';
+require_once __DIR__ . '/../includes/StatusMachine.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+$authHeader = trim((string) ($_SERVER['HTTP_AUTHORIZATION'] ?? ''));
+$apiKeyHeader = trim((string) ($_SERVER['HTTP_X_API_KEY'] ?? ''));
+$agentHeader = trim((string) ($_SERVER['HTTP_X_AGENT_IDENTITY'] ?? ''));
+$tokenQuery = trim((string) ($_GET['token'] ?? ''));
+$usingApiAuth = ($authHeader !== '') || ($apiKeyHeader !== '') || ($agentHeader !== '') || ($tokenQuery !== '');
+
+if ($usingApiAuth) {
+    $user = requireAgentOrApiKey($agentIdentity, $apiKeyRepo, $pdo, $hooks);
+} else {
+    $user = requireSession($session);
+    if (!$session->validateCsrfToken((string) ($_POST['csrf_token'] ?? ''))) {
+        http_response_code(403);
+        echo json_encode(['error' => 'CSRF token required']);
+        exit;
+    }
+}
+
+$transactionUuid = trim((string) ($_POST['transaction_uuid'] ?? ''));
+$action = trim((string) ($_POST['action'] ?? ''));
+if ($transactionUuid === '' || $action === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'transaction_uuid and action required']);
+    exit;
+}
+
+$txStmt = $pdo->prepare('SELECT uuid, buyer_uuid, store_uuid, current_status, dispute_uuid FROM v_current_cumulative_transaction_statuses WHERE uuid = ?');
+$txStmt->execute([$transactionUuid]);
+$tx = $txStmt->fetch(\PDO::FETCH_ASSOC);
+if (!$tx) {
+    http_response_code(404);
+    echo json_encode(['error' => 'Transaction not found']);
+    exit;
+}
+
+$actorUuid = (string) ($user['uuid'] ?? '');
+$isBuyer = ($tx['buyer_uuid'] ?? '') === $actorUuid;
+$isVendor = false;
+if (!$isBuyer) {
+    $vendorStmt = $pdo->prepare('SELECT 1 FROM store_users WHERE store_uuid = ? AND user_uuid = ? LIMIT 1');
+    $vendorStmt->execute([$tx['store_uuid'] ?? '', $actorUuid]);
+    $isVendor = (bool) $vendorStmt->fetchColumn();
+}
+$isStaffOrAdmin = in_array((string) ($user['role'] ?? ''), [User::ROLE_STAFF, User::ROLE_ADMIN], true);
+
+if (!$isBuyer && !$isVendor && !$isStaffOrAdmin) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Forbidden']);
+    exit;
+}
+
+$disputeStatus = 'NONE';
+if (!empty($tx['dispute_uuid'])) {
+    $disputeStmt = $pdo->prepare('SELECT status FROM disputes WHERE uuid = ? AND deleted_at IS NULL');
+    $disputeStmt->execute([$tx['dispute_uuid']]);
+    $dispute = $disputeStmt->fetch(\PDO::FETCH_ASSOC);
+    $disputeStatus = ($dispute && strtolower((string) ($dispute['status'] ?? '')) === 'resolved') ? 'RESOLVED' : 'OPEN';
+}
+
+$paymentStatus = (string) ($tx['current_status'] ?? StatusMachine::STATUS_PENDING);
+$releaseAllowed = ($paymentStatus === StatusMachine::STATUS_COMPLETED) && ($disputeStatus === 'NONE') && ($isVendor || $isStaffOrAdmin);
+$cancelAllowed = ($paymentStatus === StatusMachine::STATUS_PENDING) && ($disputeStatus === 'NONE') && ($isBuyer || $isStaffOrAdmin);
+$partialRefundAllowed = $isStaffOrAdmin && ($disputeStatus === 'OPEN');
+
+$sm = new StatusMachine($pdo);
+
+if ($action === 'release') {
+    if (!$releaseAllowed) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Action not allowed']);
+        exit;
+    }
+    $sm->requestRelease($transactionUuid, $actorUuid);
+    echo json_encode(['ok' => true, 'action' => 'release', 'transaction_uuid' => $transactionUuid, 'intent' => StatusMachine::INTENT_RELEASE]);
+    exit;
+}
+
+if ($action === 'cancel') {
+    if (!$cancelAllowed) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Action not allowed']);
+        exit;
+    }
+    $sm->requestCancel($transactionUuid, $actorUuid);
+    echo json_encode(['ok' => true, 'action' => 'cancel', 'transaction_uuid' => $transactionUuid, 'intent' => StatusMachine::INTENT_CANCEL]);
+    exit;
+}
+
+if ($action === 'partial_refund') {
+    if (!$partialRefundAllowed) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Action not allowed']);
+        exit;
+    }
+    $refundPercent = (float) ($_POST['refund_percent'] ?? 0);
+    if ($refundPercent <= 0 || $refundPercent > 100) {
+        http_response_code(400);
+        echo json_encode(['error' => 'refund_percent must be between 1 and 100']);
+        exit;
+    }
+    $sm->requestPartialRefund($transactionUuid, $refundPercent, $actorUuid);
+    echo json_encode([
+        'ok' => true,
+        'action' => 'partial_refund',
+        'transaction_uuid' => $transactionUuid,
+        'intent' => StatusMachine::INTENT_PARTIAL_REFUND,
+        'refund_percent' => $refundPercent,
+    ]);
+    exit;
+}
+
+http_response_code(400);
+echo json_encode(['error' => 'Invalid action']);

--- a/app/tests/E2E/TransactionActionsApiE2ETest.php
+++ b/app/tests/E2E/TransactionActionsApiE2ETest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+final class TransactionActionsApiE2ETest extends E2ETestCase
+{
+    public function testPostTransactionActionsWithoutAuthReturns401(): void
+    {
+        $res = self::runRequest([
+            'method' => 'POST',
+            'uri' => 'api/transaction-actions.php',
+            'get' => [],
+            'post' => [
+                'transaction_uuid' => User::generateUuid(),
+                'action' => 'release',
+            ],
+            'headers' => [],
+        ]);
+
+        $this->assertSame(401, $res['code']);
+        $data = json_decode($res['body'], true);
+        $this->assertSame('Login required', $data['error'] ?? '');
+    }
+
+    public function testPostTransactionActionsSessionWithoutCsrfReturns403(): void
+    {
+        $txUuid = $this->seedTransaction(StatusMachine::STATUS_PENDING);
+        $cookies = self::loginAs('admin', 'admin');
+        $this->assertNotEmpty($cookies);
+
+        $res = self::runRequest([
+            'method' => 'POST',
+            'uri' => 'api/transaction-actions.php',
+            'get' => [],
+            'post' => [
+                'transaction_uuid' => $txUuid,
+                'action' => 'cancel',
+            ],
+            'headers' => [],
+            'cookies' => $cookies,
+        ]);
+
+        $this->assertSame(403, $res['code']);
+        $data = json_decode($res['body'], true);
+        $this->assertSame('CSRF token required', $data['error'] ?? '');
+    }
+
+    public function testBuyerCannotRequestReleaseViaApi(): void
+    {
+        $txUuid = $this->seedTransaction(StatusMachine::STATUS_COMPLETED);
+        $cookies = self::loginAs('e2e_customer', 'password123');
+        $this->assertNotEmpty($cookies);
+        $csrf = $this->csrfForCookies($cookies);
+        $this->assertNotSame('', $csrf);
+
+        $res = self::runRequest([
+            'method' => 'POST',
+            'uri' => 'api/transaction-actions.php',
+            'get' => [],
+            'post' => [
+                'transaction_uuid' => $txUuid,
+                'action' => 'release',
+                'csrf_token' => $csrf,
+            ],
+            'headers' => [],
+            'cookies' => $cookies,
+        ]);
+
+        $this->assertSame(403, $res['code']);
+        $data = json_decode($res['body'], true);
+        $this->assertSame('Action not allowed', $data['error'] ?? '');
+    }
+
+    public function testPostTransactionActionsWithApiKeyReleaseWritesIntent(): void
+    {
+        $txUuid = $this->seedTransaction(StatusMachine::STATUS_COMPLETED);
+        $cookies = self::loginAs('admin', 'admin');
+        $this->assertNotEmpty($cookies);
+        $apiKey = $this->createApiKey($cookies, 'tx-actions-release');
+        $this->assertNotSame('', $apiKey);
+
+        $res = self::runRequest([
+            'method' => 'POST',
+            'uri' => 'api/transaction-actions.php',
+            'get' => [],
+            'post' => [
+                'transaction_uuid' => $txUuid,
+                'action' => 'release',
+            ],
+            'headers' => [
+                'Authorization' => 'Bearer ' . $apiKey,
+            ],
+        ]);
+
+        $this->assertSame(200, $res['code']);
+        $data = json_decode($res['body'], true);
+        $this->assertTrue($data['ok'] ?? false);
+        $this->assertSame('RELEASE', $data['intent'] ?? '');
+
+        $intent = $this->latestIntentForTransaction($txUuid, 'RELEASE');
+        $this->assertNotNull($intent);
+        $this->assertSame('pending', $intent['status']);
+    }
+
+    public function testPostTransactionActionsCancelWithSessionWritesIntent(): void
+    {
+        $txUuid = $this->seedTransaction(StatusMachine::STATUS_PENDING);
+        $cookies = self::loginAs('admin', 'admin');
+        $this->assertNotEmpty($cookies);
+        $csrf = $this->csrfForCookies($cookies);
+        $this->assertNotSame('', $csrf);
+
+        $res = self::runRequest([
+            'method' => 'POST',
+            'uri' => 'api/transaction-actions.php',
+            'get' => [],
+            'post' => [
+                'transaction_uuid' => $txUuid,
+                'action' => 'cancel',
+                'csrf_token' => $csrf,
+            ],
+            'headers' => [],
+            'cookies' => $cookies,
+        ]);
+
+        $this->assertSame(200, $res['code']);
+        $data = json_decode($res['body'], true);
+        $this->assertTrue($data['ok'] ?? false);
+        $this->assertSame('CANCEL', $data['intent'] ?? '');
+
+        $intent = $this->latestIntentForTransaction($txUuid, 'CANCEL');
+        $this->assertNotNull($intent);
+        $this->assertSame('pending', $intent['status']);
+    }
+
+    public function testPostTransactionActionsPartialRefundWithOpenDisputeWritesIntent(): void
+    {
+        $txUuid = $this->seedTransaction(StatusMachine::STATUS_FROZEN, true);
+        $cookies = self::loginAs('admin', 'admin');
+        $this->assertNotEmpty($cookies);
+        $csrf = $this->csrfForCookies($cookies);
+        $this->assertNotSame('', $csrf);
+
+        $res = self::runRequest([
+            'method' => 'POST',
+            'uri' => 'api/transaction-actions.php',
+            'get' => [],
+            'post' => [
+                'transaction_uuid' => $txUuid,
+                'action' => 'partial_refund',
+                'refund_percent' => '25',
+                'csrf_token' => $csrf,
+            ],
+            'headers' => [],
+            'cookies' => $cookies,
+        ]);
+
+        $this->assertSame(200, $res['code']);
+        $data = json_decode($res['body'], true);
+        $this->assertTrue($data['ok'] ?? false);
+        $this->assertSame('PARTIAL_REFUND', $data['intent'] ?? '');
+        $this->assertSame(25.0, (float) ($data['refund_percent'] ?? 0));
+
+        $intent = $this->latestIntentForTransaction($txUuid, 'PARTIAL_REFUND');
+        $this->assertNotNull($intent);
+        $params = json_decode((string) ($intent['params'] ?? ''), true);
+        $this->assertSame(25.0, (float) ($params['refund_percent'] ?? 0));
+    }
+
+    private function createApiKey(array $cookies, string $name): string
+    {
+        $csrf = $this->csrfForCookies($cookies);
+        if ($csrf === '') {
+            return '';
+        }
+        $keyRes = self::runRequest([
+            'method' => 'POST',
+            'uri' => 'api/keys.php',
+            'get' => [],
+            'post' => [
+                'name' => $name,
+                'csrf_token' => $csrf,
+            ],
+            'headers' => [],
+            'cookies' => $cookies,
+        ]);
+        if ($keyRes['code'] !== 200) {
+            return '';
+        }
+        $keyData = json_decode($keyRes['body'], true);
+        return (string) ($keyData['api_key'] ?? '');
+    }
+
+    private function csrfForCookies(array $cookies): string
+    {
+        $pageRes = self::runRequest([
+            'method' => 'GET',
+            'uri' => 'register.php',
+            'get' => [],
+            'post' => [],
+            'headers' => [],
+            'cookies' => $cookies,
+        ]);
+        return self::extractCsrfFromBody((string) ($pageRes['body'] ?? ''));
+    }
+
+    private function seedTransaction(string $status, bool $withOpenDispute = false): string
+    {
+        $pdo = Db::pdo();
+        $now = date('Y-m-d H:i:s');
+        $buyerUuid = $this->userUuidByUsername('e2e_customer');
+        $storeUuid = $this->storeUuidForUser($buyerUuid);
+        $packageUuid = $this->ensurePackageForStore($storeUuid);
+
+        $txUuid = User::generateUuid();
+        $pdo->prepare('INSERT INTO transactions (uuid, type, description, package_uuid, store_uuid, buyer_uuid, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
+            ->execute([$txUuid, 'evm', '', $packageUuid, $storeUuid, $buyerUuid, $now]);
+        $pdo->prepare('INSERT INTO evm_transactions (uuid, amount, chain_id, currency, created_at) VALUES (?, ?, ?, ?, ?)')
+            ->execute([$txUuid, 0.1, 1, 'ETH', $now]);
+        $pdo->prepare('INSERT INTO transaction_statuses (transaction_uuid, time, amount, status, comment, created_at) VALUES (?, ?, ?, ?, ?, ?)')
+            ->execute([$txUuid, $now, 0.0, $status, 'Seed status', $now]);
+
+        if ($withOpenDispute) {
+            $disputeUuid = User::generateUuid();
+            $pdo->prepare('INSERT INTO disputes (uuid, status, created_at) VALUES (?, ?, ?)')->execute([$disputeUuid, 'open', $now]);
+            $pdo->prepare('UPDATE transactions SET dispute_uuid = ?, updated_at = ? WHERE uuid = ?')->execute([$disputeUuid, $now, $txUuid]);
+        }
+
+        return $txUuid;
+    }
+
+    private function userUuidByUsername(string $username): string
+    {
+        $stmt = Db::pdo()->prepare('SELECT uuid FROM users WHERE username = ? LIMIT 1');
+        $stmt->execute([$username]);
+        return (string) $stmt->fetchColumn();
+    }
+
+    private function storeUuidForUser(string $userUuid): string
+    {
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare('SELECT store_uuid FROM store_users WHERE user_uuid = ? LIMIT 1');
+        $stmt->execute([$userUuid]);
+        $storeUuid = (string) ($stmt->fetchColumn() ?: '');
+        if ($storeUuid !== '') {
+            return $storeUuid;
+        }
+
+        $storeUuid = User::generateUuid();
+        $now = date('Y-m-d H:i:s');
+        $storename = 'e2e' . substr($storeUuid, 0, 8);
+        $pdo->prepare('INSERT INTO stores (uuid, storename, description, created_at) VALUES (?, ?, ?, ?)')
+            ->execute([$storeUuid, $storename, 'E2E', $now]);
+        $pdo->prepare('INSERT INTO store_users (store_uuid, user_uuid, role) VALUES (?, ?, ?)')
+            ->execute([$storeUuid, $userUuid, 'owner']);
+        return $storeUuid;
+    }
+
+    private function ensurePackageForStore(string $storeUuid): string
+    {
+        $pdo = Db::pdo();
+        $stmt = $pdo->prepare("SELECT uuid FROM packages WHERE store_uuid = ? AND (deleted_at IS NULL OR deleted_at = '') LIMIT 1");
+        $stmt->execute([$storeUuid]);
+        $packageUuid = (string) ($stmt->fetchColumn() ?: '');
+        if ($packageUuid !== '') {
+            return $packageUuid;
+        }
+
+        $now = date('Y-m-d H:i:s');
+        $itemUuid = User::generateUuid();
+        $pdo->prepare('INSERT INTO items (uuid, name, description, store_uuid, created_at) VALUES (?, ?, ?, ?, ?)')
+            ->execute([$itemUuid, 'E2E Tx Item', '', $storeUuid, $now]);
+        $packageUuid = User::generateUuid();
+        $pdo->prepare('INSERT INTO packages (uuid, item_uuid, store_uuid, name, created_at) VALUES (?, ?, ?, ?, ?)')
+            ->execute([$packageUuid, $itemUuid, $storeUuid, 'E2E Tx Package', $now]);
+
+        return $packageUuid;
+    }
+
+    private function latestIntentForTransaction(string $transactionUuid, string $action): ?array
+    {
+        $stmt = Db::pdo()->prepare('SELECT * FROM transaction_intents WHERE transaction_uuid = ? AND action = ? ORDER BY id DESC LIMIT 1');
+        $stmt->execute([$transactionUuid, $action]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+}

--- a/app/tests/bootstrap.php
+++ b/app/tests/bootstrap.php
@@ -105,7 +105,9 @@ if ($adminUsername !== null && $adminUsername !== '') {
         if ($storeUuid === false) {
             $storeUuid = User::generateUuid();
             $now = date('Y-m-d H:i:s');
-            $storename = 'e2e_store_' . substr(str_replace(['.', ' '], '', (string) microtime(true)), -8);
+            // storename has a DB CHECK constraint: 1..16 chars (see Schema.php).
+            // Keep this deterministic-length to avoid test bootstrap failures.
+            $storename = 'e2e' . substr(bin2hex(random_bytes(8)), 0, 13); // 3 + 13 = 16 chars
             $pdo->prepare('INSERT INTO stores (uuid, storename, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)')->execute([$storeUuid, $storename, 'E2E store', $now, $now]);
             $pdo->prepare('INSERT INTO store_users (store_uuid, user_uuid, role) VALUES (?, ?, ?)')->execute([$storeUuid, $cust['uuid'], 'owner']);
         }

--- a/docs/app/ARCHITECTURE.md
+++ b/docs/app/ARCHITECTURE.md
@@ -106,9 +106,11 @@ The marketplace application follows a hybrid PHP/Python architecture with clear 
 
 5. Vendor ships product, marks as shipped (future feature)
 
-6. Buyer confirms receipt, triggers release intent
-   ├─ PHP inserts transaction_intent (RELEASE)
-   └─ Python cron reads intent, signs transaction, releases funds
+6. Buyer confirms receipt (annotation only), vendor/staff requests release
+   ├─ Buyer confirm: updates transactions.buyer_confirmed_at
+   ├─ Release request via web POST /payment.php (action=release)
+   ├─ Or API POST /api/transaction-actions.php (action=release)
+   └─ PHP inserts transaction_intent (RELEASE)
 
 7. Python cron inserts transaction_status (RELEASED)
 ```
@@ -186,11 +188,13 @@ Views (v_current_transaction_statuses) provide this automatically
 PHP never signs blockchain transactions. Instead, it writes "intent" records that Python executes.
 
 ```
-PHP Side (web request):
+PHP Side (web/API request):
 ┌─────────────────────────────────────────────────────────┐
 │ User clicks "Release Funds"                             │
 │   ↓                                                     │
-│ POST /api/transactions/{uuid}/release                   │
+│ POST /payment.php (action=release) OR                   │
+│ POST /api/transaction-actions.php                       │
+│   (transaction_uuid, action=release)                    │
 │   ↓                                                     │
 │ StatusMachine::requestRelease($txUuid, $userUuid)      │
 │   ↓                                                     │

--- a/docs/app/DEVELOPER_GUIDE.md
+++ b/docs/app/DEVELOPER_GUIDE.md
@@ -806,6 +806,7 @@ Clawed Road follows a **"one PHP script per endpoint"** architecture. There is n
 
 - `/api/stores.php` → `public/api/stores.php`
 - `/api/transactions.php` → `public/api/transactions.php`
+- `/api/transaction-actions.php` → `public/api/transaction-actions.php`
 - `/admin/config.php` → `public/admin/config.php`
 - `/register.php` → `public/register.php`
 

--- a/docs/app/README.md
+++ b/docs/app/README.md
@@ -204,7 +204,8 @@ app/
     │   ├── keys.php         # List/create API keys
     │   ├── keys-revoke.php  # Revoke API key
     │   ├── stores.php       # List/create stores
-    │   └── transactions.php # List/create transactions
+    │   ├── transactions.php # List/create transactions
+    │   └── transaction-actions.php # Request release/cancel/partial-refund intents
     │
     ├── admin/               # Admin-only endpoints
     │   ├── config.php       # Get/set configuration
@@ -565,6 +566,18 @@ Create transaction (requires session).
 ```
 
 **Note**: Escrow address will be filled by Python cron within minutes.
+
+#### POST /api/transaction-actions.php
+Request a transaction action intent (`release`, `cancel`, `partial_refund`).
+
+**Parameters**:
+- `transaction_uuid` (string, required)
+- `action` (string, required)
+- `refund_percent` (required for `partial_refund`)
+
+**Auth**:
+- API key / agent identity (no CSRF), or
+- Session + CSRF token
 
 #### GET /api/keys.php
 List API keys for current user (requires session).

--- a/docs/app/REFERENCE.md
+++ b/docs/app/REFERENCE.md
@@ -167,6 +167,7 @@ python app/cron/cron.py
 | `/api/stores.php` | List/create stores | No/Session |
 | `/api/items.php` | List/create items | No/Session |
 | `/api/transactions.php` | List/create transactions | API Key/Session |
+| `/api/transaction-actions.php` | Request release/cancel/partial-refund intents | API Key/Session |
 | `/api/keys.php` | Manage API keys | Session |
 | `/admin/config.php` | System configuration | Admin |
 | `/admin/tokens.php` | Accepted tokens | Admin |


### PR DESCRIPTION
Add a new API endpoint for transaction actions (release, cancel, partial refund) to address a missing REST API for these operations.

This PR implements `POST /api/transaction-actions.php` to provide programmatic access to transaction intents (release, cancel, partial_refund), which were previously only available via the web UI. It includes comprehensive authentication (API key/agent or session+CSRF) and authorization checks, along with new E2E tests and updated documentation across `ARCHITECTURE.md`, `API_GUIDE.md`, `REFERENCE.md`, `README.md`, and `DEVELOPER_GUIDE.md`. A fix for a test bootstrap issue (storename length constraint) is also included to ensure the full test suite runs cleanly.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-18641575-7da5-41fd-9958-79d96f63d9f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18641575-7da5-41fd-9958-79d96f63d9f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

